### PR TITLE
upgrade Go toolchain: 1.9 -> 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9.x
+- 1.11.x
 env: PATH=/home/travis/gopath/bin:$PATH
 script:
 - make lint


### PR DESCRIPTION
fix CVE-2019-6486

https://github.com/golang/go/issues/29903