### PR TITLE
add Go Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
+.PHONY: all
 all: clean test build
 
+.PHONY: test
 test: lint
 	go test $(TESTFLAGS) ./...
 
+.PHONY: deps
 deps:
 	go get -d -v -t ./...
 
+.PHONY: devel-deps
 devel-deps: deps
 	GO111MODULE=off \
 	go get golang.org/x/lint/golint \
@@ -13,16 +17,17 @@ devel-deps: deps
 		github.com/mattn/goveralls
 
 LINT_RET = .golint.txt
+.PHONY: lint
 lint: devel-deps
 	go vet ./...
 	rm -f $(LINT_RET)
 	golint ./... | tee -a $(LINT_RET)
 	test ! -s $(LINT_RET)
 
+.PHONY: cover
 cover: devel-deps
 	tool/cover.sh
 
+.PHONY: clean
 clean:
 	go clean
-
-.PHONY: test deps devel-deps clean lint cover

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ deps:
 	go get -d -v -t ./...
 
 devel-deps: deps
+	GO111MODULE=off \
 	go get golang.org/x/lint/golint \
 		github.com/axw/gocov/gocov \
 		github.com/mattn/goveralls

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: clean test build
+all: clean test
 
 .PHONY: test
 test: lint

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mackerelio/checkers
+
+go 1.12


### PR DESCRIPTION
This adds to support Go modules.

But, I think `go mod` shouldn't manage tools such as *golint*, so this p-r set `GO111MODULE=off` temporarily.