### PR TITLE
Improve performance of status map parser

### DIFF
--- a/asstatusparse_test.go
+++ b/asstatusparse_test.go
@@ -20,10 +20,17 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:   "multi",
-			source: "unknown=critical,warning=critical",
+			name:   "uppercase",
+			source: "UNKNOWN=CRITICAL",
 			expected: map[Status]Status{
 				UNKNOWN: CRITICAL,
+			},
+		},
+		{
+			name:   "multi",
+			source: "unknown=ok,warning=critical",
+			expected: map[Status]Status{
+				UNKNOWN: OK,
 				WARNING: CRITICAL,
 			},
 		},
@@ -33,13 +40,28 @@ func TestParse(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "= error",
+			source:  "unknown critical",
+			wantErr: true,
+		},
+		{
 			name:    "to error",
 			source:  "critical=invalid",
 			wantErr: true,
 		},
 		{
 			name:    "argument error",
-			source:  "invalid=critical=invalid",
+			source:  "unknown=critical=invalid",
+			wantErr: true,
+		},
+		{
+			name:    "missing comma error",
+			source:  "unknown=criticalwarning=critical",
+			wantErr: true,
+		},
+		{
+			name:    "trailing comma error",
+			source:  "unknown=ok,",
 			wantErr: true,
 		},
 		{

--- a/checkers.go
+++ b/checkers.go
@@ -19,11 +19,11 @@ const (
 
 func (st Status) String() string {
 	switch st {
-	case 0:
+	case OK:
 		return "OK"
-	case 1:
+	case WARNING:
 		return "WARNING"
-	case 2:
+	case CRITICAL:
 		return "CRITICAL"
 	default:
 		return "UNKNOWN"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/mackerelio/checkers
 
-go 1.18
-
-require golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+go 1.20

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=


### PR DESCRIPTION
This PR proposes improvement of #20. The new implementation reduces allocations as possible, and about 30% faster. Also this way of parsing is more Go-way.

```
func BenchmarkParse(b *testing.B) {
	for i := 0; i < b.N; i++ {
		Parse("unknown=critical,warning=critical")
	}
}

name     old time/op    new time/op    delta
Parse-8     429ns ± 0%     296ns ± 1%  -31.06%  (p=0.000 n=9+10)

name     old alloc/op   new alloc/op   delta
Parse-8      256B ± 0%      240B ± 0%   -6.25%  (p=0.000 n=10+10)

name     old allocs/op  new allocs/op  delta
Parse-8      7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)
```