### PR TITLE
remove coveralls status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@ checkers
 =======
 
  [![Build Status](https://github.com/mackerelio/checkers/workflows/Build/badge.svg?branch=master)][actions]
-[![Coverage Status](https://coveralls.io/repos/mackerelio/checkers/badge.svg?branch=master)][coveralls]
 [![Apache License Version 2.0](https://img.shields.io/badge/license-APACHE2-blue.svg)][license]
 [![GoDev](https://pkg.go.dev/badge/github.com/mackerelio/checkers)][godev]
 
 [actions]: https://github.com/mackerelio/checkers/actions?workflow=Build
-[coveralls]: https://coveralls.io/r/mackerelio/checkers?branch=master
 [license]: https://github.com/mackerelio/checkers/blob/master/LICENSE
 [godev]: https://pkg.go.dev/github.com/mackerelio/checkers
 


### PR DESCRIPTION
We stopped to send code coverage to Coveralls since I was merged #27 so we should remove its badge.